### PR TITLE
Player detail modal with match history and charts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,12 @@ See @README.md for project overview and @ARCHITECTURE.md for an outline of the s
 - **Python**: Use `uv` for ALL operations - see the **python-project-management** skill for details, or use `uv help`
 - **Streamlit**: Use `uv run streamlit run app/app.py` to launch the app for you or the user to view in the browser
 
+# Code style
+
+- **Comments**: Prefer well-commented code. Add a comment whenever the intent behind a block of code is not immediately obvious from reading it — explain *why*, not just *what*.
+- **YAGNI**: Don't build for hypothetical future requirements. Implement what is needed now; extend later when the need is real.
+- **DRY**: Avoid duplicating logic. Extract shared behaviour into a reusable function or module rather than copying code across files.
+
 # Workflow
 
 All work is to be done in the following loop:

--- a/app/data.py
+++ b/app/data.py
@@ -55,6 +55,14 @@ def fetch_fixtures() -> pd.DataFrame:
 
 
 @st.cache_data(ttl=300)
+def fetch_player_history(player_id: int) -> pd.DataFrame:
+    """Per-gameweek stats for a single player (finished fixtures only)."""
+    client = get_client()
+    rows = client.rpc("player_history", {"p_player_id": player_id}).execute().data  # type: ignore[union-attr]
+    return pd.DataFrame(rows)  # type: ignore[arg-type]
+
+
+@st.cache_data(ttl=300)
 def fetch_gameweek_info() -> dict:
     """Return min/max GW ids and the next GW id (for slider defaults)."""
     client = get_client()

--- a/app/data.py
+++ b/app/data.py
@@ -46,7 +46,7 @@ def fetch_fixtures() -> pd.DataFrame:
     rows = (
         client.from_("fixtures")
         .select(
-            "gameweek_id, team_h_id, team_a_id, team_h_difficulty, team_a_difficulty"
+            "gameweek_id, team_h_id, team_a_id, team_h_difficulty, team_a_difficulty, finished"
         )
         .execute()
         .data

--- a/app/pages/fdr_matrix.py
+++ b/app/pages/fdr_matrix.py
@@ -2,16 +2,7 @@ import pandas as pd
 import streamlit as st
 
 from data import fetch_fixtures, fetch_gameweek_info, fetch_team_id_map
-
-# ── FDR colour scheme ───────────────────────────────────────────────────────
-
-FDR_COLOURS: dict[int, tuple[str, str]] = {
-    1: ("darkgreen", "white"),
-    2: ("#09fc7b", "black"),
-    3: ("#e7e7e8", "black"),
-    4: ("#ff1651", "white"),
-    5: ("#80072d", "white"),
-}
+from style import FDR_COLOURS
 
 # ── Filters ─────────────────────────────────────────────────────────────────
 

--- a/app/pages/stats.py
+++ b/app/pages/stats.py
@@ -1,11 +1,13 @@
 import math
 
+import altair as alt
 import pandas as pd
 import streamlit as st
 
 from data import (
     fetch_fixtures,
     fetch_gameweek_info,
+    fetch_player_history,
     fetch_stats,
     fetch_team_id_map,
     fetch_teams,
@@ -145,73 +147,210 @@ def _build_fdr_strip(team_short_name: str, num_gws: int = 8) -> list[dict]:
     return result
 
 
+_OUTCOME_STYLE: dict[str, str] = {
+    "W": "background-color:#00a651;color:white",
+    "D": "background-color:#e7e7e8;color:#333",
+    "L": "background-color:#e00030;color:white",
+}
+
+
+def _outcome(was_home: bool, home_score: int, away_score: int) -> str:
+    ps = home_score if was_home else away_score
+    os_ = away_score if was_home else home_score
+    if ps > os_:
+        return "W"
+    if ps < os_:
+        return "L"
+    return "D"
+
+
 @st.dialog("Player Details", width="large")
 def _show_player_detail(player_row: pd.Series) -> None:
-    """Modal showing detailed player stats and upcoming FDR strip."""
+    """Modal showing player header, key stats, per-GW history table + charts, and FDR strip."""
     # ── Header ──
-    col_shirt, col_info = st.columns([1, 4])
+    col_shirt, col_info = st.columns([1, 5])
     with col_shirt:
-        shirt_url = (
+        st.image(
             f"https://fantasy.premierleague.com/dist/img/shirts/standard/"
-            f"shirt_{int(player_row['team_code'])}-66.webp"
+            f"shirt_{int(player_row['team_code'])}-66.webp",
+            width=80,
         )
-        st.image(shirt_url, width=80)
     with col_info:
         st.subheader(player_row["player"])
         st.caption(
             f"{player_row['pos']}  ·  {player_row['team']}  ·  £{player_row['price']:.1f}"
         )
 
-    # ── Stats ──
-    st.markdown("##### Key Stats")
-    s1, s2, s3, s4 = st.columns(4)
-    s1.metric("Points", int(player_row["pts"]))
+    # ── Key stats ──
+    s1, s2, s3, s4, s5, s6, s7 = st.columns(7)
+    s1.metric("Pts", int(player_row["pts"]))
     s2.metric("P90", f"{player_row['p90']:.1f}")
     s3.metric("xP90", f"{player_row['xp90']:.1f}")
     s4.metric("TSB%", f"{player_row['tsb']:.1f}%")
+    s5.metric("ST", int(player_row["st"]))
+    s6.metric("MP%", f"{player_row['mp_pct']:.0f}%")
+    s7.metric("CS", int(player_row["cs"]))
 
-    s5, s6, s7, s8 = st.columns(4)
-    s5.metric("Starts", int(player_row["st"]))
-    s6.metric("Minutes", int(player_row["mp"]))
-    s7.metric("MP%", f"{player_row['mp_pct']:.1f}%")
-    s8.metric("Clean Sheets", int(player_row["cs"]))
+    st.divider()
 
-    s9, s10, s11, s12 = st.columns(4)
-    s9.metric("GS90", f"{player_row['gs90']:.2f}")
-    s10.metric("A90", f"{player_row['a90']:.2f}")
-    s11.metric("xG90", f"{player_row['xg90']:.2f}")
-    s12.metric("xA90", f"{player_row['xa90']:.2f}")
+    # ── Tabs ──
+    tab_hist, tab_fix = st.tabs(["History", "Fixtures"])
 
-    # ── FDR Strip ──
-    st.markdown("##### Upcoming Fixtures")
-    strip = _build_fdr_strip(player_row["team"])
-    if not strip:
-        st.caption("No upcoming fixture data available.")
-        return
+    # ── History tab ──
+    with tab_hist:
+        hist = fetch_player_history(int(player_row["player_id"]))
 
-    html_parts = []
-    for entry in strip:
-        gw = entry["gw"]
-        opponents = entry["opponents"]
-        fdr = entry["fdr"]
-        if fdr in FDR_COLOURS:
-            bg, fg = FDR_COLOURS[fdr]
+        if hist.empty:
+            st.caption("No match history available.")
         else:
-            bg, fg = "#e7e7e8", "#999"
-            opponents = "-"
-        html_parts.append(
-            f'<div style="display:inline-block;text-align:center;margin:2px;">'
-            f'<div style="font-size:0.7em;color:#666;">GW{gw}</div>'
-            f'<div style="background:{bg};color:{fg};padding:6px 10px;'
-            f'border-radius:6px;font-size:0.85em;font-weight:600;'
-            f'min-width:70px;">{opponents}</div>'
-            f"</div>"
-        )
-    st.html(
-        '<div style="display:flex;flex-wrap:wrap;gap:4px;">'
-        + "".join(html_parts)
-        + "</div>"
-    )
+            hist = hist.reset_index(drop=True)
+
+            # Derived columns
+            hist["Opponent"] = hist["opponent"] + " (" + hist["was_home"].map({True: "H", False: "A"}) + ")"
+            hist["Score"] = hist.apply(
+                lambda r: f"{r['home_score']}-{r['away_score']}"
+                if pd.notna(r["home_score"]) else "-",
+                axis=1,
+            )
+            outcomes = hist.apply(
+                lambda r: _outcome(r["was_home"], int(r["home_score"]), int(r["away_score"]))
+                if pd.notna(r["home_score"]) else "?",
+                axis=1,
+            )
+
+            display_hist = hist.rename(columns={
+                "gameweek_id": "GW",
+                "goals_scored": "GS",
+                "assists": "A",
+                "cs": "CS",
+                "goals_conceded": "GC",
+                "own_goals": "OG",
+                "penalties_saved": "PS",
+                "penalties_missed": "PM",
+                "yellow_cards": "YC",
+                "red_cards": "RC",
+                "saves": "S",
+                "bonus": "B",
+                "bps": "BPS",
+                "pts": "Pts",
+                "starts": "ST",
+                "minutes": "MP",
+                "xg": "xG",
+                "xa": "xA",
+                "xgi": "xGI",
+                "xgc": "xGC",
+                "influence": "I",
+                "creativity": "C",
+                "threat": "T",
+                "ict_index": "ICT",
+                "xpts": "xPts",
+            })[[
+                "GW", "Opponent", "Score", "Pts", "xPts", "ST", "MP",
+                "GS", "A", "xG", "xA", "xGI",
+                "CS", "GC", "xGC",
+                "OG", "PS", "PM", "YC", "RC", "S", "B", "BPS",
+                "I", "C", "T", "ICT",
+            ]]
+
+            score_col_idx = list(display_hist.columns).index("Score")
+
+            def _style_row(row: pd.Series) -> list[str]:
+                styles = [""] * len(row)
+                styles[score_col_idx] = _OUTCOME_STYLE.get(outcomes[row.name], "")
+                return styles
+
+            styled = display_hist.style.apply(_style_row, axis=1)
+            st.dataframe(styled, hide_index=True, width="stretch", height=350)
+
+            # ── Charts ──
+            chart_df = hist[["gameweek_id", "goals_scored", "assists", "xgi"]].copy()
+            chart_df = chart_df.sort_values("gameweek_id").reset_index(drop=True)
+            chart_df["gi"] = chart_df["goals_scored"] + chart_df["assists"]
+            chart_df["gi_delta"] = (chart_df["gi"] - chart_df["xgi"]).round(2)
+            chart_df["cum_gi"] = chart_df["gi"].cumsum()
+            chart_df["cum_xgi"] = chart_df["xgi"].cumsum()
+
+            # GI delta bar chart
+            delta_max = max(chart_df["gi_delta"].abs().max(), 0.5)
+            bar = (
+                alt.Chart(chart_df)
+                .mark_bar()
+                .encode(
+                    x=alt.X("gameweek_id:O", title="GW"),
+                    y=alt.Y("gi_delta:Q", title="GI delta"),
+                    color=alt.Color(
+                        "gi_delta:Q",
+                        scale=alt.Scale(
+                            scheme="redyellowgreen",
+                            domain=[-delta_max, delta_max],
+                        ),
+                        legend=alt.Legend(title="GI delta"),
+                    ),
+                    tooltip=[
+                        alt.Tooltip("gameweek_id:O", title="GW"),
+                        alt.Tooltip("gi_delta:Q", title="GI delta", format=".2f"),
+                    ],
+                )
+                .properties(title="GI − xGI delta  (positive = overperforming)")
+            )
+            st.altair_chart(bar, use_container_width=True)
+
+            # Cumulative GI vs xGI line chart
+            cum_melted = chart_df.melt(
+                id_vars=["gameweek_id"],
+                value_vars=["cum_gi", "cum_xgi"],
+                var_name="variable",
+                value_name="value",
+            )
+            cum_melted["variable"] = cum_melted["variable"].map(
+                {"cum_gi": "GI", "cum_xgi": "xGI"}
+            )
+            line = (
+                alt.Chart(cum_melted)
+                .mark_line(point=True)
+                .encode(
+                    x=alt.X("gameweek_id:Q", title="GW"),
+                    y=alt.Y("value:Q", title="Cumulative"),
+                    color=alt.Color("variable:N", legend=alt.Legend(title="")),
+                    tooltip=[
+                        alt.Tooltip("gameweek_id:Q", title="GW"),
+                        alt.Tooltip("variable:N", title="Metric"),
+                        alt.Tooltip("value:Q", title="Value", format=".2f"),
+                    ],
+                )
+                .properties(title="Cumulative GI and xGI")
+            )
+            st.altair_chart(line, use_container_width=True)
+
+    # ── Fixtures tab ──
+    with tab_fix:
+        strip = _build_fdr_strip(player_row["team"])
+        if not strip:
+            st.caption("No upcoming fixture data available.")
+        else:
+            html_parts = []
+            for entry in strip:
+                gw = entry["gw"]
+                opponents = entry["opponents"]
+                fdr = entry["fdr"]
+                if fdr in FDR_COLOURS:
+                    bg, fg = FDR_COLOURS[fdr]
+                else:
+                    bg, fg = "#e7e7e8", "#999"
+                    opponents = "-"
+                html_parts.append(
+                    f'<div style="display:inline-block;text-align:center;margin:2px;">'
+                    f'<div style="font-size:0.7em;color:#666;">GW{gw}</div>'
+                    f'<div style="background:{bg};color:{fg};padding:6px 10px;'
+                    f'border-radius:6px;font-size:0.85em;font-weight:600;'
+                    f'min-width:70px;">{opponents}</div>'
+                    f"</div>"
+                )
+            st.html(
+                '<div style="display:flex;flex-wrap:wrap;gap:4px;">'
+                + "".join(html_parts)
+                + "</div>"
+            )
 
 
 # ── Table ─────────────────────────────────────────────────────────────────────

--- a/app/pages/stats.py
+++ b/app/pages/stats.py
@@ -83,12 +83,12 @@ df = df.loc[df["price"] <= max_price]
 df = df.loc[df["mp_pct"] >= min_mp_pct]
 df = df.reset_index(drop=True)
 
-# Build shirt image URL from team code.
 df["shirt"] = df["team_code"].apply(
     lambda c: (
         f"https://fantasy.premierleague.com/dist/img/shirts/standard/shirt_{c}-66.webp"
     )
 )
+df["player_team"] = df["player"] + " · " + df["team"]
 
 # ── Player detail modal ──────────────────────────────────────────────────────
 
@@ -225,7 +225,7 @@ display = df.filter(
     items=[
         "shirt",
         "pos",
-        "player",
+        "player_team",
         "price",
         "st",
         "mp",
@@ -248,7 +248,7 @@ display = df.filter(
     columns={
         "shirt": "Team",
         "pos": "Pos",
-        "player": "Player",
+        "player_team": "Player",
         "price": "£",
         "st": "ST",
         "mp": "MP",
@@ -269,29 +269,25 @@ display = df.filter(
     }
 )
 
-if "editor_key" not in st.session_state:
-    st.session_state.editor_key = 0
+display.insert(0, "ℹ️", "ℹ️")
 
-display.insert(0, "ℹ️", False)
-
-edited = st.data_editor(
+event = st.dataframe(
     display,
-    hide_index=True,
     use_container_width=True,
+    hide_index=True,
     column_config={
-        "ℹ️": st.column_config.CheckboxColumn("ℹ️", default=False, width="small"),
+        "ℹ️": st.column_config.TextColumn("ℹ️", width="small"),
         "Team": st.column_config.ImageColumn("Team", width="small"),
         "£": st.column_config.NumberColumn(format="%.1f"),
         "TSB%": st.column_config.NumberColumn(format="%.1f"),
         "P90": st.column_config.NumberColumn(format="%.1f"),
         "MP%": st.column_config.NumberColumn(format="%.1f"),
     },
-    disabled=[col for col in display.columns if col != "ℹ️"],
-    key=f"player_stats_editor_{st.session_state.editor_key}",
+    on_select="rerun",
+    selection_mode="single-row",
+    key="player_stats_table",
 )
 
-selected_rows = edited[edited["ℹ️"]]
-if not selected_rows.empty:
-    selected_idx = selected_rows.index[0]
-    st.session_state.editor_key += 1  # reset editor on next rerun to clear the tick
+if event.selection.rows:
+    selected_idx = event.selection.rows[0]
     _show_player_detail(df.iloc[selected_idx])

--- a/app/pages/stats.py
+++ b/app/pages/stats.py
@@ -83,6 +83,8 @@ df = df.loc[df["price"] <= max_price]
 df = df.loc[df["mp_pct"] >= min_mp_pct]
 df = df.reset_index(drop=True)
 
+df["info"] = "ℹ️"
+
 # Build shirt image URL from team code.
 df["shirt"] = df["team_code"].apply(
     lambda c: (
@@ -218,11 +220,12 @@ def _show_player_detail(player_row: pd.Series) -> None:
 # ── Table ─────────────────────────────────────────────────────────────────────
 
 st.markdown("## Player stats")
-st.caption("Click on columns for sorting")
+st.caption("Click a row to see player details · Click column headers to sort")
 
 # Select and rename columns for display (internal snake_case → readable headers).
 display = df.filter(
     items=[
+        "info",
         "shirt",
         "pos",
         "team",
@@ -247,6 +250,7 @@ display = df.filter(
     ]
 ).rename(
     columns={
+        "info": "ℹ️",
         "shirt": " ",
         "pos": "Pos",
         "team": "Team",

--- a/app/pages/stats.py
+++ b/app/pages/stats.py
@@ -217,7 +217,7 @@ def _show_player_detail(player_row: pd.Series) -> None:
 # ── Table ─────────────────────────────────────────────────────────────────────
 
 st.markdown("## Player stats")
-st.caption("Click a row to see player details · Click column headers to sort")
+st.caption("Click a row to view player details · Click column headers to sort")
 
 # Select and rename columns for display (internal snake_case → readable headers).
 display = df.filter(
@@ -268,15 +268,13 @@ display = df.filter(
     }
 )
 
-display.insert(0, "ℹ️", "ℹ️")
-
 event = st.dataframe(
     display,
-    use_container_width=True,
+    width="stretch",
     hide_index=True,
     column_config={
-        "ℹ️": st.column_config.TextColumn("ℹ️", width="small"),
         "Team": st.column_config.ImageColumn("Team", width="small"),
+        "Player": st.column_config.TextColumn("Player"),
         "£": st.column_config.NumberColumn(format="%.1f"),
         "TSB%": st.column_config.NumberColumn(format="%.1f"),
         "P90": st.column_config.NumberColumn(format="%.1f"),

--- a/app/pages/stats.py
+++ b/app/pages/stats.py
@@ -3,7 +3,14 @@ import math
 import pandas as pd
 import streamlit as st
 
-from data import fetch_stats, fetch_teams
+from data import (
+    fetch_fixtures,
+    fetch_gameweek_info,
+    fetch_stats,
+    fetch_team_id_map,
+    fetch_teams,
+)
+from style import FDR_COLOURS
 
 # ── Filters ──────────────────────────────────────────────────────────────────
 
@@ -74,6 +81,7 @@ if pos_filter != "All":
 
 df = df.loc[df["price"] <= max_price]
 df = df.loc[df["mp_pct"] >= min_mp_pct]
+df = df.reset_index(drop=True)
 
 # Build shirt image URL from team code.
 df["shirt"] = df["team_code"].apply(
@@ -81,6 +89,131 @@ df["shirt"] = df["team_code"].apply(
         f"https://fantasy.premierleague.com/dist/img/shirts/standard/shirt_{c}-66.webp"
     )
 )
+
+# ── Player detail modal ──────────────────────────────────────────────────────
+
+
+def _build_fdr_strip(team_short_name: str, num_gws: int = 8) -> list[dict]:
+    """Build upcoming fixture difficulty data for a team."""
+    team_id_map = fetch_team_id_map()
+    name_to_id = {v: k for k, v in team_id_map.items()}
+    team_id = name_to_id.get(team_short_name)
+    if team_id is None:
+        return []
+
+    gw_info = fetch_gameweek_info()
+    next_gw = gw_info["next_gw"]
+    max_gw = gw_info["max_gw"]
+    end_gw = min(next_gw + num_gws - 1, max_gw)
+
+    fixtures = fetch_fixtures()
+    fx = fixtures[
+        (~fixtures["finished"])
+        & (fixtures["gameweek_id"] >= next_gw)
+        & (fixtures["gameweek_id"] <= end_gw)
+    ].copy()
+
+    # Split into home/away rows for this team.
+    home = fx.loc[
+        fx["team_h_id"] == team_id,
+        ["gameweek_id", "team_a_id", "team_h_difficulty"],
+    ].rename(columns={"team_a_id": "opponent_id", "team_h_difficulty": "fdr"})
+    home["venue"] = "H"
+
+    away = fx.loc[
+        fx["team_a_id"] == team_id,
+        ["gameweek_id", "team_h_id", "team_a_difficulty"],
+    ].rename(columns={"team_h_id": "opponent_id", "team_a_difficulty": "fdr"})
+    away["venue"] = "A"
+
+    team_fx = pd.concat([home, away], ignore_index=True)
+    team_fx["opponent"] = team_fx["opponent_id"].map(team_id_map)
+    team_fx["fragment"] = team_fx["opponent"] + " (" + team_fx["venue"] + ")"
+
+    grouped = team_fx.groupby("gameweek_id").agg(
+        opponents=("fragment", " ".join),
+        fdr=("fdr", "max"),
+    ).reset_index()
+
+    gw_data = grouped.set_index("gameweek_id")
+    result = []
+    for gw in range(next_gw, end_gw + 1):
+        if gw in gw_data.index:
+            row = gw_data.loc[gw]
+            result.append({"gw": gw, "opponents": row["opponents"], "fdr": int(row["fdr"])})
+        else:
+            result.append({"gw": gw, "opponents": "", "fdr": 0})
+    return result
+
+
+@st.dialog("Player Details", width="large")
+def _show_player_detail(player_row: pd.Series) -> None:
+    """Modal showing detailed player stats and upcoming FDR strip."""
+    # ── Header ──
+    col_shirt, col_info = st.columns([1, 4])
+    with col_shirt:
+        shirt_url = (
+            f"https://fantasy.premierleague.com/dist/img/shirts/standard/"
+            f"shirt_{int(player_row['team_code'])}-66.webp"
+        )
+        st.image(shirt_url, width=80)
+    with col_info:
+        st.subheader(player_row["player"])
+        st.caption(
+            f"{player_row['pos']}  ·  {player_row['team']}  ·  £{player_row['price']:.1f}"
+        )
+
+    # ── Stats ──
+    st.markdown("##### Key Stats")
+    s1, s2, s3, s4 = st.columns(4)
+    s1.metric("Points", int(player_row["pts"]))
+    s2.metric("P90", f"{player_row['p90']:.1f}")
+    s3.metric("xP90", f"{player_row['xp90']:.1f}")
+    s4.metric("TSB%", f"{player_row['tsb']:.1f}%")
+
+    s5, s6, s7, s8 = st.columns(4)
+    s5.metric("Starts", int(player_row["st"]))
+    s6.metric("Minutes", int(player_row["mp"]))
+    s7.metric("MP%", f"{player_row['mp_pct']:.1f}%")
+    s8.metric("Clean Sheets", int(player_row["cs"]))
+
+    s9, s10, s11, s12 = st.columns(4)
+    s9.metric("GS90", f"{player_row['gs90']:.2f}")
+    s10.metric("A90", f"{player_row['a90']:.2f}")
+    s11.metric("xG90", f"{player_row['xg90']:.2f}")
+    s12.metric("xA90", f"{player_row['xa90']:.2f}")
+
+    # ── FDR Strip ──
+    st.markdown("##### Upcoming Fixtures")
+    strip = _build_fdr_strip(player_row["team"])
+    if not strip:
+        st.caption("No upcoming fixture data available.")
+        return
+
+    html_parts = []
+    for entry in strip:
+        gw = entry["gw"]
+        opponents = entry["opponents"]
+        fdr = entry["fdr"]
+        if fdr in FDR_COLOURS:
+            bg, fg = FDR_COLOURS[fdr]
+        else:
+            bg, fg = "#e7e7e8", "#999"
+            opponents = "-"
+        html_parts.append(
+            f'<div style="display:inline-block;text-align:center;margin:2px;">'
+            f'<div style="font-size:0.7em;color:#666;">GW{gw}</div>'
+            f'<div style="background:{bg};color:{fg};padding:6px 10px;'
+            f'border-radius:6px;font-size:0.85em;font-weight:600;'
+            f'min-width:70px;">{opponents}</div>'
+            f"</div>"
+        )
+    st.html(
+        '<div style="display:flex;flex-wrap:wrap;gap:4px;">'
+        + "".join(html_parts)
+        + "</div>"
+    )
+
 
 # ── Table ─────────────────────────────────────────────────────────────────────
 
@@ -138,7 +271,7 @@ display = df.filter(
     }
 )
 
-st.dataframe(
+event = st.dataframe(
     display,
     width="stretch",
     hide_index=True,
@@ -149,4 +282,11 @@ st.dataframe(
         "P90": st.column_config.NumberColumn(format="%.1f"),
         "MP%": st.column_config.NumberColumn(format="%.1f"),
     },
+    on_select="rerun",
+    selection_mode="single-row",
+    key="player_stats_table",
 )
+
+if event.selection.rows:
+    selected_idx = event.selection.rows[0]
+    _show_player_detail(df.iloc[selected_idx])

--- a/app/pages/stats.py
+++ b/app/pages/stats.py
@@ -85,6 +85,7 @@ df = df.loc[df["price"] <= max_price]
 df = df.loc[df["mp_pct"] >= min_mp_pct]
 df = df.reset_index(drop=True)
 
+# Build shirt image URL from team code.
 df["shirt"] = df["team_code"].apply(
     lambda c: (
         f"https://fantasy.premierleague.com/dist/img/shirts/standard/shirt_{c}-66.webp"

--- a/app/pages/stats.py
+++ b/app/pages/stats.py
@@ -191,166 +191,175 @@ def _show_player_detail(player_row: pd.Series) -> None:
     s6.metric("MP%", f"{player_row['mp_pct']:.0f}%")
     s7.metric("CS", int(player_row["cs"]))
 
+    # ── Upcoming fixtures ──
+    strip = _build_fdr_strip(player_row["team"])
+    if strip:
+        html_parts = []
+        for entry in strip:
+            gw = entry["gw"]
+            opponents = entry["opponents"]
+            fdr = entry["fdr"]
+            if fdr in FDR_COLOURS:
+                bg, fg = FDR_COLOURS[fdr]
+            else:
+                bg, fg = "#e7e7e8", "#999"
+                opponents = "-"
+            html_parts.append(
+                f'<div style="display:inline-block;text-align:center;margin:2px;">'
+                f'<div style="font-size:0.7em;color:#666;">GW{gw}</div>'
+                f'<div style="background:{bg};color:{fg};padding:6px 10px;'
+                f'border-radius:6px;font-size:0.85em;font-weight:600;'
+                f'min-width:70px;">{opponents}</div>'
+                f"</div>"
+            )
+        st.html(
+            '<div style="display:flex;flex-wrap:wrap;gap:4px;">'
+            + "".join(html_parts)
+            + "</div>"
+        )
+
     st.divider()
 
-    # ── Tabs ──
-    tab_hist, tab_fix = st.tabs(["History", "Fixtures"])
+    # ── History ──
+    hist = fetch_player_history(int(player_row["player_id"]))
 
-    # ── History tab ──
-    with tab_hist:
-        hist = fetch_player_history(int(player_row["player_id"]))
+    if hist.empty:
+        st.caption("No match history available.")
+    else:
+        hist = hist.reset_index(drop=True)
 
-        if hist.empty:
-            st.caption("No match history available.")
-        else:
-            hist = hist.reset_index(drop=True)
+        # Derived columns
+        hist["Opponent"] = hist["opponent"] + " (" + hist["was_home"].map({True: "H", False: "A"}) + ")"
+        hist["Score"] = hist.apply(
+            lambda r: f"{int(r['home_score'])}-{int(r['away_score'])}"
+            if pd.notna(r["home_score"]) else "-",
+            axis=1,
+        )
+        outcomes = hist.apply(
+            lambda r: _outcome(r["was_home"], int(r["home_score"]), int(r["away_score"]))
+            if pd.notna(r["home_score"]) else "?",
+            axis=1,
+        )
 
-            # Derived columns
-            hist["Opponent"] = hist["opponent"] + " (" + hist["was_home"].map({True: "H", False: "A"}) + ")"
-            hist["Score"] = hist.apply(
-                lambda r: f"{r['home_score']}-{r['away_score']}"
-                if pd.notna(r["home_score"]) else "-",
-                axis=1,
-            )
-            outcomes = hist.apply(
-                lambda r: _outcome(r["was_home"], int(r["home_score"]), int(r["away_score"]))
-                if pd.notna(r["home_score"]) else "?",
-                axis=1,
-            )
+        display_hist = hist.rename(columns={
+            "gameweek_id": "GW",
+            "goals_scored": "GS",
+            "assists": "A",
+            "cs": "CS",
+            "goals_conceded": "GC",
+            "own_goals": "OG",
+            "penalties_saved": "PS",
+            "penalties_missed": "PM",
+            "yellow_cards": "YC",
+            "red_cards": "RC",
+            "saves": "S",
+            "bonus": "B",
+            "bps": "BPS",
+            "pts": "Pts",
+            "starts": "ST",
+            "minutes": "MP",
+            "xg": "xG",
+            "xa": "xA",
+            "xgi": "xGI",
+            "xgc": "xGC",
+            "influence": "I",
+            "creativity": "C",
+            "threat": "T",
+            "ict_index": "ICT",
+            "xpts": "xPts",
+        })[[
+            "GW", "Opponent", "Score", "Pts", "xPts", "ST", "MP",
+            "GS", "A", "xG", "xA", "xGI",
+            "CS", "GC", "xGC",
+            "OG", "PS", "PM", "YC", "RC", "S", "B", "BPS",
+            "I", "C", "T", "ICT",
+        ]]
 
-            display_hist = hist.rename(columns={
-                "gameweek_id": "GW",
-                "goals_scored": "GS",
-                "assists": "A",
-                "cs": "CS",
-                "goals_conceded": "GC",
-                "own_goals": "OG",
-                "penalties_saved": "PS",
-                "penalties_missed": "PM",
-                "yellow_cards": "YC",
-                "red_cards": "RC",
-                "saves": "S",
-                "bonus": "B",
-                "bps": "BPS",
-                "pts": "Pts",
-                "starts": "ST",
-                "minutes": "MP",
-                "xg": "xG",
-                "xa": "xA",
-                "xgi": "xGI",
-                "xgc": "xGC",
-                "influence": "I",
-                "creativity": "C",
-                "threat": "T",
-                "ict_index": "ICT",
-                "xpts": "xPts",
-            })[[
-                "GW", "Opponent", "Score", "Pts", "xPts", "ST", "MP",
-                "GS", "A", "xG", "xA", "xGI",
-                "CS", "GC", "xGC",
-                "OG", "PS", "PM", "YC", "RC", "S", "B", "BPS",
-                "I", "C", "T", "ICT",
-            ]]
+        score_col_idx = list(display_hist.columns).index("Score")
 
-            score_col_idx = list(display_hist.columns).index("Score")
+        def _style_row(row: pd.Series) -> list[str]:
+            styles = [""] * len(row)
+            styles[score_col_idx] = _OUTCOME_STYLE.get(outcomes[row.name], "")
+            return styles
 
-            def _style_row(row: pd.Series) -> list[str]:
-                styles = [""] * len(row)
-                styles[score_col_idx] = _OUTCOME_STYLE.get(outcomes[row.name], "")
-                return styles
+        styled = display_hist.style.apply(_style_row, axis=1)
+        st.dataframe(
+            styled,
+            hide_index=True,
+            width="stretch",
+            height=350,
+            column_config={
+                "xPts": st.column_config.NumberColumn(format="%.2f"),
+                "xG":   st.column_config.NumberColumn(format="%.2f"),
+                "xA":   st.column_config.NumberColumn(format="%.2f"),
+                "xGI":  st.column_config.NumberColumn(format="%.2f"),
+                "xGC":  st.column_config.NumberColumn(format="%.2f"),
+                "I":    st.column_config.NumberColumn(format="%.1f"),
+                "C":    st.column_config.NumberColumn(format="%.1f"),
+                "T":    st.column_config.NumberColumn(format="%.1f"),
+                "ICT":  st.column_config.NumberColumn(format="%.1f"),
+            },
+        )
 
-            styled = display_hist.style.apply(_style_row, axis=1)
-            st.dataframe(styled, hide_index=True, width="stretch", height=350)
+        # ── Charts ──
+        chart_df = hist[["gameweek_id", "goals_scored", "assists", "xgi"]].copy()
+        chart_df = chart_df.sort_values("gameweek_id").reset_index(drop=True)
+        chart_df["gi"] = chart_df["goals_scored"] + chart_df["assists"]
+        chart_df["gi_delta"] = (chart_df["gi"] - chart_df["xgi"]).round(2)
+        chart_df["cum_gi"] = chart_df["gi"].cumsum()
+        chart_df["cum_xgi"] = chart_df["xgi"].cumsum()
 
-            # ── Charts ──
-            chart_df = hist[["gameweek_id", "goals_scored", "assists", "xgi"]].copy()
-            chart_df = chart_df.sort_values("gameweek_id").reset_index(drop=True)
-            chart_df["gi"] = chart_df["goals_scored"] + chart_df["assists"]
-            chart_df["gi_delta"] = (chart_df["gi"] - chart_df["xgi"]).round(2)
-            chart_df["cum_gi"] = chart_df["gi"].cumsum()
-            chart_df["cum_xgi"] = chart_df["xgi"].cumsum()
-
-            # GI delta bar chart
-            delta_max = max(chart_df["gi_delta"].abs().max(), 0.5)
-            bar = (
-                alt.Chart(chart_df)
-                .mark_bar()
-                .encode(
-                    x=alt.X("gameweek_id:O", title="GW"),
-                    y=alt.Y("gi_delta:Q", title="GI delta"),
-                    color=alt.Color(
-                        "gi_delta:Q",
-                        scale=alt.Scale(
-                            scheme="redyellowgreen",
-                            domain=[-delta_max, delta_max],
-                        ),
-                        legend=alt.Legend(title="GI delta"),
+        # GI delta bar chart
+        delta_max = max(float(chart_df["gi_delta"].abs().max()), 0.5)
+        bar = (
+            alt.Chart(chart_df)
+            .mark_bar()
+            .encode(
+                x=alt.X("gameweek_id:O", title="GW"),
+                y=alt.Y("gi_delta:Q", title="GI delta"),
+                color=alt.Color(
+                    "gi_delta:Q",
+                    scale=alt.Scale(
+                        scheme="redyellowgreen",
+                        domain=[-delta_max, delta_max],
                     ),
-                    tooltip=[
-                        alt.Tooltip("gameweek_id:O", title="GW"),
-                        alt.Tooltip("gi_delta:Q", title="GI delta", format=".2f"),
-                    ],
-                )
-                .properties(title="GI − xGI delta  (positive = overperforming)")
+                    legend=alt.Legend(title="GI delta"),
+                ),
+                tooltip=[
+                    alt.Tooltip("gameweek_id:O", title="GW"),
+                    alt.Tooltip("gi_delta:Q", title="GI delta", format=".2f"),
+                ],
             )
-            st.altair_chart(bar, use_container_width=True)
+            .properties(title="GI − xGI delta  (positive = overperforming)")
+        )
+        st.altair_chart(bar, use_container_width=True)
 
-            # Cumulative GI vs xGI line chart
-            cum_melted = chart_df.melt(
-                id_vars=["gameweek_id"],
-                value_vars=["cum_gi", "cum_xgi"],
-                var_name="variable",
-                value_name="value",
+        # Cumulative GI vs xGI line chart
+        cum_melted = chart_df.melt(
+            id_vars=["gameweek_id"],
+            value_vars=["cum_gi", "cum_xgi"],
+            var_name="variable",
+            value_name="value",
+        )
+        cum_melted["variable"] = cum_melted["variable"].map(
+            {"cum_gi": "GI", "cum_xgi": "xGI"}
+        )
+        line = (
+            alt.Chart(cum_melted)
+            .mark_line(point=True)
+            .encode(
+                x=alt.X("gameweek_id:Q", title="GW"),
+                y=alt.Y("value:Q", title="Cumulative"),
+                color=alt.Color("variable:N", legend=alt.Legend(title="")),
+                tooltip=[
+                    alt.Tooltip("gameweek_id:Q", title="GW"),
+                    alt.Tooltip("variable:N", title="Metric"),
+                    alt.Tooltip("value:Q", title="Value", format=".2f"),
+                ],
             )
-            cum_melted["variable"] = cum_melted["variable"].map(
-                {"cum_gi": "GI", "cum_xgi": "xGI"}
-            )
-            line = (
-                alt.Chart(cum_melted)
-                .mark_line(point=True)
-                .encode(
-                    x=alt.X("gameweek_id:Q", title="GW"),
-                    y=alt.Y("value:Q", title="Cumulative"),
-                    color=alt.Color("variable:N", legend=alt.Legend(title="")),
-                    tooltip=[
-                        alt.Tooltip("gameweek_id:Q", title="GW"),
-                        alt.Tooltip("variable:N", title="Metric"),
-                        alt.Tooltip("value:Q", title="Value", format=".2f"),
-                    ],
-                )
-                .properties(title="Cumulative GI and xGI")
-            )
-            st.altair_chart(line, use_container_width=True)
-
-    # ── Fixtures tab ──
-    with tab_fix:
-        strip = _build_fdr_strip(player_row["team"])
-        if not strip:
-            st.caption("No upcoming fixture data available.")
-        else:
-            html_parts = []
-            for entry in strip:
-                gw = entry["gw"]
-                opponents = entry["opponents"]
-                fdr = entry["fdr"]
-                if fdr in FDR_COLOURS:
-                    bg, fg = FDR_COLOURS[fdr]
-                else:
-                    bg, fg = "#e7e7e8", "#999"
-                    opponents = "-"
-                html_parts.append(
-                    f'<div style="display:inline-block;text-align:center;margin:2px;">'
-                    f'<div style="font-size:0.7em;color:#666;">GW{gw}</div>'
-                    f'<div style="background:{bg};color:{fg};padding:6px 10px;'
-                    f'border-radius:6px;font-size:0.85em;font-weight:600;'
-                    f'min-width:70px;">{opponents}</div>'
-                    f"</div>"
-                )
-            st.html(
-                '<div style="display:flex;flex-wrap:wrap;gap:4px;">'
-                + "".join(html_parts)
-                + "</div>"
-            )
+            .properties(title="Cumulative GI and xGI")
+        )
+        st.altair_chart(line, use_container_width=True)
 
 
 # ── Table ─────────────────────────────────────────────────────────────────────

--- a/app/pages/stats.py
+++ b/app/pages/stats.py
@@ -88,7 +88,6 @@ df["shirt"] = df["team_code"].apply(
         f"https://fantasy.premierleague.com/dist/img/shirts/standard/shirt_{c}-66.webp"
     )
 )
-df["player_team"] = df["player"] + " · " + df["team"]
 
 # ── Player detail modal ──────────────────────────────────────────────────────
 
@@ -225,7 +224,7 @@ display = df.filter(
     items=[
         "shirt",
         "pos",
-        "player_team",
+        "player",
         "price",
         "st",
         "mp",
@@ -248,7 +247,7 @@ display = df.filter(
     columns={
         "shirt": "Team",
         "pos": "Pos",
-        "player_team": "Player",
+        "player": "Player",
         "price": "£",
         "st": "ST",
         "mp": "MP",

--- a/app/pages/stats.py
+++ b/app/pages/stats.py
@@ -83,8 +83,6 @@ df = df.loc[df["price"] <= max_price]
 df = df.loc[df["mp_pct"] >= min_mp_pct]
 df = df.reset_index(drop=True)
 
-df["info"] = "ℹ️"
-
 # Build shirt image URL from team code.
 df["shirt"] = df["team_code"].apply(
     lambda c: (
@@ -225,10 +223,8 @@ st.caption("Click a row to see player details · Click column headers to sort")
 # Select and rename columns for display (internal snake_case → readable headers).
 display = df.filter(
     items=[
-        "info",
         "shirt",
         "pos",
-        "team",
         "player",
         "price",
         "st",
@@ -250,10 +246,8 @@ display = df.filter(
     ]
 ).rename(
     columns={
-        "info": "ℹ️",
-        "shirt": " ",
+        "shirt": "Team",
         "pos": "Pos",
-        "team": "Team",
         "player": "Player",
         "price": "£",
         "st": "ST",
@@ -275,22 +269,29 @@ display = df.filter(
     }
 )
 
-event = st.dataframe(
+if "editor_key" not in st.session_state:
+    st.session_state.editor_key = 0
+
+display.insert(0, "ℹ️", False)
+
+edited = st.data_editor(
     display,
-    width="stretch",
     hide_index=True,
+    use_container_width=True,
     column_config={
-        " ": st.column_config.ImageColumn(" ", width="small"),
+        "ℹ️": st.column_config.CheckboxColumn("ℹ️", default=False, width="small"),
+        "Team": st.column_config.ImageColumn("Team", width="small"),
         "£": st.column_config.NumberColumn(format="%.1f"),
         "TSB%": st.column_config.NumberColumn(format="%.1f"),
         "P90": st.column_config.NumberColumn(format="%.1f"),
         "MP%": st.column_config.NumberColumn(format="%.1f"),
     },
-    on_select="rerun",
-    selection_mode="single-row",
-    key="player_stats_table",
+    disabled=[col for col in display.columns if col != "ℹ️"],
+    key=f"player_stats_editor_{st.session_state.editor_key}",
 )
 
-if event.selection.rows:
-    selected_idx = event.selection.rows[0]
+selected_rows = edited[edited["ℹ️"]]
+if not selected_rows.empty:
+    selected_idx = selected_rows.index[0]
+    st.session_state.editor_key += 1  # reset editor on next rerun to clear the tick
     _show_player_detail(df.iloc[selected_idx])

--- a/app/style.py
+++ b/app/style.py
@@ -1,0 +1,10 @@
+# Shared visual constants used across pages.
+
+# FDR colour scheme: maps fixture difficulty rating (1-5) to (background, foreground).
+FDR_COLOURS: dict[int, tuple[str, str]] = {
+    1: ("darkgreen", "white"),
+    2: ("#09fc7b", "black"),
+    3: ("#e7e7e8", "black"),
+    4: ("#ff1651", "white"),
+    5: ("#80072d", "white"),
+}

--- a/db/functions/player_history.sql
+++ b/db/functions/player_history.sql
@@ -1,0 +1,76 @@
+-- Per-gameweek stats for a single player, ordered most-recent first.
+-- Returns one row per finished fixture with opponent info, result scores,
+-- and all key per-game stats needed for the player detail modal.
+
+CREATE OR REPLACE FUNCTION public.player_history(p_player_id int)
+RETURNS TABLE (
+    gameweek_id      int,
+    opponent         text,
+    opponent_code    int,
+    was_home         boolean,
+    home_score       int,
+    away_score       int,
+    pts              int,
+    starts           int,
+    minutes          int,
+    goals_scored     int,
+    assists          int,
+    xg               numeric,
+    xa               numeric,
+    xgi              numeric,
+    cs               int,
+    goals_conceded   int,
+    xgc              numeric,
+    own_goals        int,
+    penalties_saved  int,
+    penalties_missed int,
+    yellow_cards     int,
+    red_cards        int,
+    saves            int,
+    bonus            int,
+    bps              int,
+    influence        numeric,
+    creativity       numeric,
+    threat           numeric,
+    ict_index        numeric,
+    xpts             numeric
+)
+LANGUAGE sql STABLE SECURITY DEFINER AS $$
+    SELECT
+        v.gameweek_id,
+        t.short_name                               AS opponent,
+        t.code                                     AS opponent_code,
+        v.was_home,
+        f.team_h_score                             AS home_score,
+        f.team_a_score                             AS away_score,
+        v.total_points                             AS pts,
+        v.starts,
+        v.minutes,
+        v.goals_scored,
+        v.assists,
+        ROUND(v.expected_goals, 2)                 AS xg,
+        ROUND(v.expected_assists, 2)               AS xa,
+        ROUND(v.expected_goal_involvements, 2)     AS xgi,
+        v.clean_sheets                             AS cs,
+        v.goals_conceded,
+        ROUND(v.expected_goals_conceded, 2)        AS xgc,
+        v.own_goals,
+        v.penalties_saved,
+        v.penalties_missed,
+        v.yellow_cards,
+        v.red_cards,
+        v.saves,
+        v.bonus,
+        v.bps,
+        ROUND(v.influence, 2)                      AS influence,
+        ROUND(v.creativity, 2)                     AS creativity,
+        ROUND(v.threat, 2)                         AS threat,
+        ROUND(v.ict_index, 2)                      AS ict_index,
+        ROUND(v.xpts, 2)                           AS xpts
+    FROM public.player_gameweek_stats v
+    JOIN raw.fixtures f ON f.id = v.fixture_id
+    JOIN raw.teams    t ON t.id = v.opponent_team_id
+    WHERE v.player_id = p_player_id
+      AND f.finished = true
+    ORDER BY v.gameweek_id DESC
+$$;


### PR DESCRIPTION
## Summary

- Clicking a player row in the stats table opens a modal with detailed per-player data
- FDR fixture strip (next 8 GWs, colour-coded by difficulty) sits beneath the 7 key season stats
- **History tab**: scrollable per-GW table (Score with W/D/L colour badge, Pts, xPts, ST, MP, GS, A, xG, xA, xGI, CS, GC, xGC, OG, PS, PM, YC, RC, S, B, BPS, ICT)
- **GI − xGI delta bar chart** (red-yellow-green, positive = overperforming)
- **Cumulative GI and xGI line chart**

## New database object

`public.player_history(p_player_id int)` — per-finished-fixture stats for a player, joining opponent team name/code and match scores from `raw.fixtures`.

## Test plan

- [ ] Click a player row — modal opens with correct player name, price, position, team
- [ ] FDR strip shows upcoming fixtures with correct colours
- [ ] History table rows match expected results (score badge green=W, grey=D, red=L)
- [ ] Decimal columns (xG, xA, xGI, xGC, xPts) display to 2dp; ICT columns to 1dp
- [ ] GI delta chart bars are coloured correctly (green above zero, red below)
- [ ] Cumulative chart shows two lines (GI and xGI) trending over the season
- [ ] Close modal and open a different player — data updates correctly
- [ ] FDR Matrix page unaffected (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)