### PR TITLE
Replace deprecated use_container_width with width='stretch'

### DIFF
--- a/app/pages/stats.py
+++ b/app/pages/stats.py
@@ -420,7 +420,7 @@ def _show_player_detail(
                     ],
                 )
             )
-            st.altair_chart(chart, use_container_width=True)
+            st.altair_chart(chart, width='stretch')
 
         # Derived columns
         hist["Opponent"] = (
@@ -563,7 +563,7 @@ def _show_player_detail(
             )
             .properties(title="GI − xGI delta  (positive = overperforming)")
         )
-        st.altair_chart(bar, use_container_width=True)
+        st.altair_chart(bar, width='stretch')
 
         # Cumulative GI vs xGI line chart
         cum_melted = chart_df.melt(
@@ -590,7 +590,7 @@ def _show_player_detail(
             )
             .properties(title="Cumulative GI and xGI")
         )
-        st.altair_chart(line, use_container_width=True)
+        st.altair_chart(line, width='stretch')
 
 
 # ── Table ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Replaced `use_container_width=True` with `width='stretch'` in all three `st.altair_chart` calls in [app/pages/stats.py](app/pages/stats.py) (lines 423, 566, 593)
- Streamlit is removing `use_container_width` after 2025-12-31 — `width='stretch'` is the documented replacement

## Test plan
- [x] Grep across `app/` confirms no remaining `use_container_width` occurrences
- [x] `uv run streamlit run app/app.py` starts cleanly with no deprecation warnings
- [ ] Manual UX check: open the player modal and the GI/xGI section to confirm charts still render full-width