### PR TITLE
Add FPL API contract tests as ETL pre-ingest gate

### DIFF
--- a/.github/workflows/etl.yml
+++ b/.github/workflows/etl.yml
@@ -15,6 +15,9 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
+      - name: Validate FPL API schema
+        run: uv run --group dev pytest test/ -v
+
       - name: Run ETL pipeline
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,19 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Run tests
+        run: uv run --group dev pytest test/ -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,4 +20,5 @@ build-backend = "uv_build"
 [dependency-groups]
 dev = [
     "prek>=0.3.8",
+    "pytest>=8.0",
 ]

--- a/test/test_api_contract.py
+++ b/test/test_api_contract.py
@@ -1,0 +1,41 @@
+"""Contract tests: verify the live FPL API still matches our Pydantic models.
+
+Run before the ETL in CI so schema drift fails fast, before any writes.
+"""
+
+from fplstat.fpl_client import (
+    fetch_bootstrap,
+    fetch_fixtures,
+    fetch_player_histories,
+)
+from fplstat.models import (
+    Fixture,
+    Gameweek,
+    Player,
+    PlayerGameweekStat,
+    Team,
+)
+from fplstat.transforms import _parse
+
+
+def test_bootstrap_and_fixtures_match_schema():
+    """bootstrap-static (teams, events, elements) and fixtures parse cleanly."""
+    bootstrap = fetch_bootstrap()
+    _parse(Team, bootstrap["teams"], "teams")
+    _parse(Gameweek, bootstrap["events"], "gameweeks")
+    _parse(Player, bootstrap["elements"], "players")
+
+    fixtures = fetch_fixtures()
+    _parse(Fixture, fixtures, "fixtures")
+
+
+def test_player_history_matches_schema():
+    """element-summary history rows parse cleanly for a sample of players."""
+    bootstrap = fetch_bootstrap()
+    # Small sample keeps the test fast and polite to the FPL API.
+    sample_ids = [p["id"] for p in bootstrap["elements"][:5]]
+    histories = fetch_player_histories(sample_ids)
+    rows = [row for history in histories.values() for row in history]
+    # Histories can legitimately be empty early in a season.
+    if rows:
+        _parse(PlayerGameweekStat, rows, "player_gameweek_stats")

--- a/uv.lock
+++ b/uv.lock
@@ -289,6 +289,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "prek" },
+    { name = "pytest" },
 ]
 
 [package.metadata]
@@ -304,7 +305,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "prek", specifier = ">=0.3.8" }]
+dev = [
+    { name = "prek", specifier = ">=0.3.8" },
+    { name = "pytest", specifier = ">=8.0" },
+]
 
 [[package]]
 name = "fsspec"
@@ -419,6 +423,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -851,6 +864,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "polars"
 version = "1.39.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1230,6 +1252,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/74/3a/0a9d837478912ce51d1583bc4352818e8933252207d05d3021e91103e084/pyroaring-1.0.4-cp314-cp314t-win32.whl", hash = "sha256:f9a111e668f026849a22a7e4cab628e41e48bb87bd2a9aea72bca75edcd7a6f2", size = 234160, upload-time = "2026-03-19T13:57:07.848Z" },
     { url = "https://files.pythonhosted.org/packages/50/9d/bcd304935f20ce5f9ecb2837df69516be657e144da350a73a1899985aa38/pyroaring-1.0.4-cp314-cp314t-win_amd64.whl", hash = "sha256:92fdad43421ad2e076639f7a0d9ee815713b98bfe07dd9107ef3ea91ff0f3b37", size = 298468, upload-time = "2026-03-19T13:57:08.94Z" },
     { url = "https://files.pythonhosted.org/packages/a6/4d/bd52a55dcef5cde4d0dda8c80000463c6929c7faba2466d9fa58fd0d48f8/pyroaring-1.0.4-cp314-cp314t-win_arm64.whl", hash = "sha256:c291428f148450e0609d5b1201b81e8248b3262770e51fc4c89768529ee36df0", size = 234175, upload-time = "2026-03-19T13:57:10.071Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Two pytest tests hit the live FPL API and validate responses through the existing Pydantic models via `transforms._parse`, so there's no duplicated validation logic.
- Wired into `.github/workflows/etl.yml` as a `Validate FPL API schema` step that runs **before** `Run ETL pipeline` — schema drift fails the workflow before any Supabase writes.
- Adds `pytest>=8.0` to the `dev` dependency group.

## Test plan
- [x] `uv run --group dev pytest test/ --collect-only` — 2 tests collected, imports resolve.
- [ ] On merge / next scheduled run, confirm the `Validate FPL API schema` step runs green before the ETL step.
- [ ] (Optional) Simulate drift locally by adding a required field to `Team` in `src/fplstat/models.py` and rerunning pytest to see the readable per-row failure message.

https://claude.ai/code/session_01HEdBbcSnNx4oEs6rc3cvo9